### PR TITLE
Fix everyone/here mentions.

### DIFF
--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -6,9 +6,9 @@ export const RoleMentionRegex = /^<@&(\d{17,20})>/;
 
 export const UserMentionRegex = /^<@!?(\d{17,20})>/;
 
-export const EveryoneRegex = /^@everyone$/;
+export const EveryoneRegex = /^@everyone/;
 
-export const HereRegex = /^@here$/;
+export const HereRegex = /^@here/;
 
 export const BlockQuoteRegex = /^( *>>> ([\s\S]*))|^( *> [^\n]*(\n *> [^\n]*)*\n?)/;
 


### PR DESCRIPTION
Fixes everyone/here mentions. If there is content after the mention it won't render correctly.

Before the change:
![image](https://github.com/ItzDerock/discord-markdown-parser/assets/50887230/cbeb6a49-5d74-45cb-aa59-91015f18dc75)

After the change:

![image](https://github.com/ItzDerock/discord-markdown-parser/assets/50887230/bad495c7-e594-44c9-906f-7c5dbb5b94e1)
