### PR TITLE
feat: add heading support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { here } from './rules/discord/here';
 import { emoticon } from './rules/emoticon';
 import { user } from './rules/discord/user';
 import { spoiler } from './rules/spoiler';
+import { heading } from './rules/heading';
 import { text } from './rules/text';
 import { url } from './rules/url';
 import { em } from './rules/em';
@@ -37,6 +38,7 @@ export const rules = {
   emoticon,
   br,
   spoiler,
+  heading,
 
   // discord specific
   user,

--- a/src/rules/heading.ts
+++ b/src/rules/heading.ts
@@ -1,0 +1,15 @@
+import SimpleMarkdown from 'simple-markdown';
+import { extend } from '../utils/extend';
+import { HeadingRegex } from '../utils/regex';
+
+export const heading = extend(
+  {
+    match: function (source, state) {
+      if (state.prevCapture === null || state.prevCapture[0] === '\n') {
+        return HeadingRegex.exec(source);
+      }
+      return null;
+    },
+  },
+  SimpleMarkdown.defaultRules.heading
+);

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -23,3 +23,5 @@ export const StrikeThroughRegex = /^~~([\s\S]+?)~~(?!_)/;
 export const TextRegex = /^[\s\S]+?(?=[^0-9A-Za-z\s]|\n\n|\n|\w+:\S|$)/;
 
 export const TimestampRegex = /^<t:(\d+)(?::(R|t|T|d|D|f|F))?>/;
+
+export const HeadingRegex = /^(#{1,3}) +([^\n]+?)(\n|$)/;

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -325,4 +325,82 @@ describe('Parse', () => {
       },
     ]);
   })
+
+  test('GIVEN a header with 1-3 "#" signs THEN parse the header', () => {
+    expect(parse('# Header')).toEqual([
+      {
+        type: 'heading',
+        level: 1,
+        content: [{
+          type: 'text',
+          content: 'Header',
+        }],
+      },
+    ]);
+    expect(parse('## Header')).toEqual([
+      {
+        type: 'heading',
+        level: 2,
+        content: [{
+          type: 'text',
+          content: 'Header',
+        }],
+      },
+    ]);
+    expect(parse('### Header')).toEqual([
+      {
+        type: 'heading',
+        level: 3,
+        content: [{
+          type: 'text',
+          content: 'Header',
+        }],
+      },
+    ]);
+    expect(parse('#### Header')).toEqual([
+      {
+        type: 'text',
+        content: '#',
+      },
+      {
+        type: 'text',
+        content: '#',
+      },
+      {
+        type: 'text',
+        content: '#',
+      },
+      {
+        type: 'text',
+        content: '# Header',
+      },
+    ]);
+    expect(parse('This is # Not a header')).toEqual([
+      {
+        type: 'text',
+        content: 'This is ',
+      },
+      {
+        type: 'text',
+        content: '# Not a header',
+      },
+    ]);
+    expect(parse('This is \n# A header')).toEqual([
+      {
+        type: 'text',
+        content: 'This is ',
+      },
+      {
+        type: 'br',
+      },
+      {
+        type: 'heading',
+        level: 1,
+        content: [{
+          type: 'text',
+          content: 'A header',
+        }],
+      },
+    ]);
+  })
 });


### PR DESCRIPTION
Adds a parsing rule for headings

Unlike normal markdown, it seems like discord only allows up to 3 levels, so "#### abc" is just treated as text instead.