### PR TITLE
feat: support guild navigation and slash command mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Designed to be used for [discord-html-transcripts](https://github.com/ItzDerock/
 -   @everyone
 -   @here
 -   emojis
+-   slash command mentions
+-   guild navigation mentions
 -   & more
 
 ## Usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import SimpleMarkdown, { type ParserRule } from '@khanacademy/simple-markdown';
 
 // import all the rules
+import { guildNavigation } from './rules/discord/guildNavigation';
 import { slashCommand } from './rules/discord/slashCommand';
 import { everyone } from './rules/discord/everyone';
 import { twemoji } from './rules/discord/twemoji';
@@ -53,6 +54,7 @@ export const rules: Record<string, ParserRule> = {
   twemoji,
   timestamp,
   slashCommand,
+  guildNavigation,
 };
 
 // for use in webhooks, embeds, etc

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import SimpleMarkdown, { type ParserRule } from '@khanacademy/simple-markdown';
 
 // import all the rules
+import { slashCommand } from './rules/discord/slashCommand';
 import { everyone } from './rules/discord/everyone';
 import { twemoji } from './rules/discord/twemoji';
 import { channel } from './rules/discord/channel';
@@ -51,6 +52,7 @@ export const rules: Record<string, ParserRule> = {
   here,
   twemoji,
   timestamp,
+  slashCommand,
 };
 
 // for use in webhooks, embeds, etc

--- a/src/rules/discord/guildNavigation.ts
+++ b/src/rules/discord/guildNavigation.ts
@@ -1,0 +1,28 @@
+import SimpleMarkdown, { type ParserRule } from '@khanacademy/simple-markdown';
+import { GuildNavigationRegex } from '../../utils/regex';
+
+export const guildNavigation: ParserRule = {
+  order: SimpleMarkdown.defaultRules.strong.order,
+  match: (source) => GuildNavigationRegex.exec(source),
+  parse: function (capture) {
+    // linked-roles navigation type adds an optional role ID
+    const navigation = capture[2] ?? capture[3];
+
+    if (navigation === 'linked-roles') {
+      // the start of the roleId is padded with a colon,
+      // so we need to remove it
+      const roleId = capture[4]?.slice(1) ?? null;
+
+      return {
+        id: capture[1],
+        navigation,
+        roleId,
+      };
+    } else {
+      return {
+        id: capture[1],
+        navigation,
+      };
+    }
+  },
+};

--- a/src/rules/discord/slashCommand.ts
+++ b/src/rules/discord/slashCommand.ts
@@ -1,0 +1,34 @@
+import SimpleMarkdown, { type ParserRule } from '@khanacademy/simple-markdown';
+import { SlashCommandRegex } from '../../utils/regex';
+
+export const slashCommand: ParserRule = {
+  order: SimpleMarkdown.defaultRules.strong.order,
+  match: (source) => SlashCommandRegex.exec(source),
+  parse: function (capture) {
+    // Commands can come in three variants:
+    // 1. /command
+    // 2. /command subcommand
+    // 3. /command subcommand-group subcommand
+    const commandParts = capture[1].split(' ');
+
+    const returnValue = {
+      fullName: capture[1],
+      name: commandParts[0],
+      subcommand: null as string | null,
+      subcommandGroup: null as string | null,
+      id: capture[2],
+    };
+
+    // length of 2 means no subcommand group
+    if (commandParts.length == 2) {
+      returnValue.subcommand = commandParts[1];
+    }
+
+    if (commandParts.length === 3) {
+      returnValue.subcommandGroup = commandParts[1];
+      returnValue.subcommand = commandParts[2];
+    }
+
+    return returnValue;
+  },
+};

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,4 +1,3 @@
-
 /**
  * Matches Discord channel mentions.
  * @example <#123456789012345678>
@@ -114,7 +113,7 @@ export const HeadingRegex = /^(#{1,3}) +([^\n]+?)(\n|$)/;
 export const SubtextRegex = /^-# +([^\n]+?)(\n|$)/;
 
 /**
- * Matches for slash command mentions,
+ * Matches for slash command mentions.
  *
  * @example </command:123456789012345678>
  *
@@ -124,3 +123,13 @@ export const SubtextRegex = /^-# +([^\n]+?)(\n|$)/;
  */
 export const SlashCommandRegex =
   /^<\/([-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}(?: [-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}){0,2})?:(\d{17,21})>$/u;
+
+/**
+ * Matches for guild navigation mentions.
+ * The `linked-roles` type adds in another opptional :ROLE-ID field.
+ *
+ * @example <12345679012345678:customize>
+ *
+ * @see {@link https://discord.com/developers/docs/reference#message-formatting-guild-navigation-types} for available types
+ */
+export const GuildNavigationRegex = /^<(\d{17,20}):(?:(customize|browse|guide)|(linked-roles)(:\d{17,20})?)>/;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -27,3 +27,6 @@ export const TimestampRegex = /^<t:(-?\d+)(?::(R|t|T|d|D|f|F))?>/;
 export const HeadingRegex = /^(#{1,3}) +([^\n]+?)(\n|$)/;
 
 export const SubtextRegex = /^-# +([^\n]+?)(\n|$)/;
+
+export const SlashCommandRegex =
+  /^<\/([-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}(?: [-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}){0,2})?:(\d{17,21})>$/u;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -94,7 +94,7 @@ export const TextRegex = /^[\s\S]+?(?=[^0-9A-Za-z\s]|\n\n|\n|\w+:\S|$)/;
  *
  * @example <t:123456> or <t:123456:t> for specific formats
  */
-export const TimestampRegex = /^<t:(-?\d+)(?::(R|t|T|d|D|f|F))?>/i;
+export const TimestampRegex = /^<t:(-?\d+)(?::(R|t|T|d|D|f|F))?>/;
 
 /**
  * Matches markdown headings (H1-H3 level).

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,32 +1,126 @@
+
+/**
+ * Matches Discord channel mentions.
+ * @example <#123456789012345678>
+ *
+ * The regex captures a 17-20 digit channel ID inside <#...> brackets.
+ */
 export const ChannelMentionRegex = /^<#(\d{17,20})>/;
 
+/**
+ * Matches custom emoji mentions.
+ * @example <:smile:12345678901234567>
+ *
+ * The regex captures:
+ * - Optional "a" for animated emojis
+ * - Emoji name (2-32 characters)
+ * - Emoji ID (17-21 digits)
+ */
 export const EmojiRegex = /^<(a)?:(\w{2,32}):(\d{17,21})>/;
 
+/**
+ * Matches Discord role mentions.
+ * @example <@&123456789012345678>
+ *
+ * The regex captures a 17-20 digit role ID inside <@&...> brackets.
+ */
 export const RoleMentionRegex = /^<@&(\d{17,20})>/;
 
+/**
+ * Matches Discord user mentions.
+ *
+ * @example <@123456789012345678> or <@!123456789012345678>
+ *
+ * The regex captures a 17-20 digit user ID, optionally preceded by "!".
+ */
 export const UserMentionRegex = /^<@!?(\d{17,20})>/;
 
+/**
+ * Matches the @everyone mention.
+ */
 export const EveryoneRegex = /^@everyone/;
 
+/**
+ * Matches the @here mention.
+ */
 export const HereRegex = /^@here/;
 
+/**
+ * Matches block quotes in two formats:
+ * 1. Single line: ">>> text"
+ * 2. Multi-line: "> text\n> more text"
+ *
+ * @example >>> This is a block quote
+ */
 export const BlockQuoteRegex = /^( *>>> ([\s\S]*))|^( *> [^\n]*(\n *> [^\n]*)*\n?)/;
 
+/**
+ * Matches code blocks with optional language specification.
+ *
+ * @example ```javascript
+ * const example = "code";
+ * ```
+ */
 export const CodeBlockRegex = /^```(([a-z0-9_+\-.#]+?)\n+)?\n*([^]+?)\n*```/i;
 
+/**
+ * Matches the ¯\_(ツ)_/¯ emoticon.
+ */
 export const EmoticonRegex = /^(¯\\_\(ツ\)_\/¯)/;
 
+/**
+ * Matches spoiler text wrapped in double pipes.
+ *
+ * @example ||This is a spoiler||
+ */
 export const SpoilerRegex = /^\|\|([\s\S]+?)\|\|/;
 
+/**
+ * Matches strikethrough text wrapped in tildes.
+ *
+ * @example ~~This text is strikethrough~~
+ */
 export const StrikeThroughRegex = /^~~([\s\S]+?)~~(?!_)/;
 
+/**
+ * Matches plain text content in messages.
+ *
+ * This regex is designed to capture text up to certain delimiters
+ * like punctuation, newlines, or specific patterns.
+ */
 export const TextRegex = /^[\s\S]+?(?=[^0-9A-Za-z\s]|\n\n|\n|\w+:\S|$)/;
 
-export const TimestampRegex = /^<t:(-?\d+)(?::(R|t|T|d|D|f|F))?>/;
+/**
+ * Matches Discord timestamp mentions.
+ *
+ * @example <t:123456> or <t:123456:t> for specific formats
+ */
+export const TimestampRegex = /^<t:(-?\d+)(?::(R|t|T|d|D|f|F))?>/i;
 
+/**
+ * Matches markdown headings (H1-H3 level).
+ *
+ * @example # Heading
+ * @example ## Subheading
+ * @example ### Subsubheading
+ */
 export const HeadingRegex = /^(#{1,3}) +([^\n]+?)(\n|$)/;
 
+/**
+ * Matches subtext in markdown headings.
+ *
+ * @example -# Subtext
+ */
 export const SubtextRegex = /^-# +([^\n]+?)(\n|$)/;
 
+/**
+ * Matches for slash command mentions,
+ *
+ * @example </command:123456789012345678>
+ *
+ * Slash command names can be up to 32 characters long,
+ * and the regex for the name was taken from the discord api documentation
+ * Commands can also be nested up to 3 times (</command group subcommand:id>)
+ */
 export const SlashCommandRegex =
   /^<\/([-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}(?: [-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}){0,2})?:(\d{17,21})>$/u;

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -572,4 +572,39 @@ describe('Parse', () => {
       },
     ]);
   });
+
+  test('GIVEN a slash command mention THEN parse the slash command mention', () => {
+    expect(parse('</command:123456789123456780>')).toEqual([
+      {
+        type: 'slashCommand',
+        fullName: 'command',
+        name: 'command',
+        subcommand: null,
+        subcommandGroup: null,
+        id: '123456789123456780',
+      },
+    ]);
+
+    expect(parse('</configure patchnotes:920459734757277696>')).toEqual([
+      {
+        type: 'slashCommand',
+        fullName: 'configure patchnotes',
+        name: 'configure',
+        subcommand: 'patchnotes',
+        subcommandGroup: null,
+        id: '920459734757277696',
+      },
+    ]);
+
+    expect(parse('</name subcommandGroup subcommand:12345678912345123123>')).toEqual([
+      {
+        type: 'slashCommand',
+        fullName: 'name subcommandGroup subcommand',
+        name: 'name',
+        subcommand: 'subcommand',
+        subcommandGroup: 'subcommandGroup',
+        id: '12345678912345123123',
+      },
+    ]);
+  });
 });

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -607,4 +607,82 @@ describe('Parse', () => {
       },
     ]);
   });
+
+  test('GIVEN a guild navigation customize mention THEN parse the guild navigation mention', () => {
+    expect(parse('<123456789123456780:customize>')).toEqual([
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'customize',
+      },
+    ]);
+  });
+
+  test('GIVEN a guild navigation browse mention THEN parse the guild navigation mention', () => {
+    expect(parse('<123456789123456780:browse>')).toEqual([
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'browse',
+      },
+    ]);
+  });
+
+  test('GIVEN a guild navigation guide mention THEN parse the guild navigation mention', () => {
+    expect(parse('<123456789123456780:guide>')).toEqual([
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'guide',
+      },
+    ]);
+  });
+
+  test('GIVEN a guild navigation linked-roles mention without role ID THEN parse the guild navigation mention', () => {
+    expect(parse('<123456789123456780:linked-roles>')).toEqual([
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'linked-roles',
+        roleId: null,
+      },
+    ]);
+  });
+
+  test('GIVEN a guild navigation linked-roles mention with role ID THEN parse the guild navigation mention', () => {
+    expect(parse('<123456789123456780:linked-roles:987654321987654321>')).toEqual([
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'linked-roles',
+        roleId: '987654321987654321',
+      },
+    ]);
+  });
+
+  test('GIVEN a message with mixed guild navigation mentions THEN parse them correctly', () => {
+    expect(
+      parse('Check out <123456789123456780:customize> and <987654321987654321:linked-roles:123456789123456789>')
+    ).toEqual([
+      {
+        type: 'text',
+        content: 'Check out ',
+      },
+      {
+        type: 'guildNavigation',
+        id: '123456789123456780',
+        navigation: 'customize',
+      },
+      {
+        type: 'text',
+        content: ' and ',
+      },
+      {
+        type: 'guildNavigation',
+        id: '987654321987654321',
+        navigation: 'linked-roles',
+        roleId: '123456789123456789',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Fix #17 

Now supports:
- Slash commands with subcommands and groups: `</command:1234...>`, `</command group subcommand:12345...>`
- Guild navigation mentions for customize, browse, and guide: `<123456789:customize>`, `<123456789:browse>`, `<123456789:guide>`
- Guild navigation linked-roles with optional role ID: `<123456789:linked-roles>`, `<123456789:linked-roles:987654321>`

also refactored the regex file to add comments for each regex.