### PR TITLE
Fix regex pattern for SlashCommand

### DIFF
--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -122,7 +122,7 @@ export const SubtextRegex = /^-# +([^\n]+?)(\n|$)/;
  * Commands can also be nested up to 3 times (</command group subcommand:id>)
  */
 export const SlashCommandRegex =
-  /^<\/([-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}(?: [-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}){0,2})?:(\d{17,21})>$/u;
+  /^<\/([-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}(?: [-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}){0,2})?:(\d{17,21})>/u;
 
 /**
  * Matches for guild navigation mentions.


### PR DESCRIPTION
Please check https://github.com/ItzDerock/discord-markdown-parser/issues/23

## Current
<img width="578" height="387" alt="Image" src="https://github.com/user-attachments/assets/4f354b84-ca6d-47d9-9672-a8c2e8bc9a69" />

## What I fixed
discord-markdown-parser/dist/utils/regex.js
<img width="1786" height="237" alt="Image" src="https://github.com/user-attachments/assets/5713f413-5eb1-4d09-9c3d-4aaaf36562c5" />
remove `$`

## Result

<img width="665" height="501" alt="Image" src="https://github.com/user-attachments/assets/11e33105-8f42-4cdc-9570-9f7cf798278d" />